### PR TITLE
MAINT: Added Error types for excepts and a temp bug fix for map_to_grid iter object.

### DIFF
--- a/pyart/core/radar.py
+++ b/pyart/core/radar.py
@@ -937,5 +937,8 @@ def _gate_altitude_data_factory(radar):
     """ Return a function which returns the gate altitudes. """
     def _gate_altitude_data():
         """ The function which returns the gate altitudes. """
-        return np.mean(radar.altitude['data']) + radar.gate_z['data']
+        try:
+            return radar.altitude['data'] + radar.gate_z['data']
+        except ValueError:
+            return np.mean(radar.altitude['data']) + radar.gate_z['data']
     return _gate_altitude_data

--- a/pyart/map/gates_to_grid.py
+++ b/pyart/map/gates_to_grid.py
@@ -91,7 +91,7 @@ def map_gates_to_grid(
     if grid_origin_alt is None:
         try:
             grid_origin_alt = float(radars[0].altitude['data'])
-        except:
+        except TypeError:
             grid_origin_alt = np.mean(radars[0].altitude['data'])
 
     gatefilters = _parse_gatefilters(gatefilters, radars)
@@ -179,7 +179,7 @@ def _find_projparams(grid_origin, radars, grid_projection):
         try:
             lat = float(radars[0].latitude['data'])
             lon = float(radars[0].longitude['data'])
-        except:
+        except TypeError:
             lat = np.mean(radars[0].latitude['data'])
             lon = np.mean(radars[0].longitude['data'])
         grid_origin = (lat, lon)
@@ -230,7 +230,7 @@ def _find_offsets(radars, projparams, grid_origin_alt):
         try:
             z_disp = float(radar.altitude['data']) - grid_origin_alt
             offsets.append((z_disp, float(y_disp), float(x_disp)))
-        except:
+        except TypeError:
             z_disp = np.mean(radar.altitude['data']) - grid_origin_alt
             offsets.append((z_disp, np.mean(y_disp), np.mean(x_disp)))
     return offsets

--- a/pyart/map/grid_mapper.py
+++ b/pyart/map/grid_mapper.py
@@ -420,7 +420,7 @@ def map_to_grid(radars, grid_shape, grid_limits, grid_origin=None,
         try:
             lat = float(radars[0].latitude['data'])
             lon = float(radars[0].longitude['data'])
-        except:
+        except TypeError:
             lat = np.mean(radars[0].latitude['data'])
             lon = np.mean(radars[0].longitude['data'])
         grid_origin = (lat, lon)
@@ -429,7 +429,7 @@ def map_to_grid(radars, grid_shape, grid_limits, grid_origin=None,
     if grid_origin_alt is None:
         try:
             grid_origin_alt = float(radars[0].altitude['data'])
-        except:
+        except TypeError:
             grid_origin_alt = np.mean(radars[0].altitude['data'])
 
     # fields which should be mapped, None for fields which are in all radars
@@ -483,7 +483,7 @@ def map_to_grid(radars, grid_shape, grid_limits, grid_origin=None,
         try:
             z_disp = float(radar.altitude['data']) - grid_origin_alt
             offsets.append((z_disp, float(y_disp), float(x_disp)))
-        except:
+        except TypeError:
             z_disp = np.mean(radar.altitude['data']) - grid_origin_alt
             offsets.append((z_disp, np.mean(y_disp), np.mean(x_disp)))
 
@@ -495,16 +495,13 @@ def map_to_grid(radars, grid_shape, grid_limits, grid_origin=None,
             xg_loc, yg_loc = geographic_to_cartesian(
                 radar.gate_longitude['data'], radar.gate_latitude['data'],
                 projparams)
-        try:
-            zg_loc = radar.gate_altitude['data'] - grid_origin_alt
-        except ValueError:
-            zg_loc = np.mean(radar.gate_altitude['data'], axis=1) - grid_origin_alt
+        zg_loc = radar.gate_altitude['data'] - grid_origin_alt
 
         # add gate locations to gate_locations array
         start, end = gate_offset[iradar], gate_offset[iradar + 1]
-        gate_locations[start:end, 0] = zg_loc.flat
-        gate_locations[start:end, 1] = yg_loc.flat
-        gate_locations[start:end, 2] = xg_loc.flat
+        gate_locations[start:end, 0] = zg_loc.flat[:]
+        gate_locations[start:end, 1] = yg_loc.flat[:]
+        gate_locations[start:end, 2] = xg_loc.flat[:]
         del xg_loc, yg_loc
 
         # determine which gates should be included in the interpolation


### PR DESCRIPTION
Hi Robin, I figured out the conflict. I added the error names, and removed the np.mean and try except for the lines below and reverted to the original:
```python
try:
     zg_loc = radar.gate_altitude['data'] - grid_origin_alt
except ValueError:	
      zg_loc = np.mean(radar.gate_altitude['data'], axis=1) - grid_origin_alt
```
Because it seems the issue was stemming from the lines:
 ```python
gate_locations[start:end, 0] = zg_loc.flat
 gate_locations[start:end, 1] = yg_loc.flat
 gate_locations[start:end, 2] = xg_loc.flat
```